### PR TITLE
Fix cursor mapping across newlines

### DIFF
--- a/eWriter2/TextOperations.swift
+++ b/eWriter2/TextOperations.swift
@@ -221,7 +221,7 @@ func getCursorParagraphInfo(text: String, cursorPosition: Int, selectionStart: I
         
     }
     
-    guard !(paragraphIndex == 0 && positionInParagraph == 0) else {
+    if cursorPosition > text.count {
         cursorParagraphInfo = CursorParagraphInfo(paragraphIndex: lastIndex, positionInParagraph: lastParagraphLength, selectionInfo: convertSelectionInfoToJSONString(selectionInfo: selectionInfo))
         return cursorParagraphInfo
     }
@@ -257,29 +257,29 @@ func convertSelectionInfoToJSONString(selectionInfo: [(paragraphIndex: Int, star
 }
 
 func recalculateCursorPosition(text: String, position: Int) -> Int {
-    guard position >= 0 && position <= text.count else {
-            print("Position out of bounds.")
-            return position
-        }
-        
-        // Get the substring up to the given position
-        let index = text.index(text.startIndex, offsetBy: position)
-        let substring = text[text.startIndex..<index]
-        
-        // Count the occurrences of '\n' in the substring
-        let numberOfLineBreaks = substring.filter { $0 == "\n" }.count
-        
-        return position + numberOfLineBreaks
-    
+    guard position >= 0 else {
+        print("Position out of bounds.")
+        return 0
+    }
+
+    var visibleCount = 0
+
+    for (actualIndex, char) in text.enumerated() {
+        if char == "\n" { continue }
+        if visibleCount == position { return actualIndex }
+        visibleCount += 1
+    }
+
+    return text.count
 }
 
 func recalculateSelectionPosition(text: String, position: Int, start: Bool) -> Int {
-    let basePosition = recalculateCursorPosition(text: text, position: position)
-//    print("basePosition: \(basePosition), start: \(start)")
-    guard basePosition >= 0  else { return 0 }
-    guard basePosition < text.count else { return text.count }
+    let actualPosition = recalculateCursorPosition(text: text, position: position)
+//    print("basePosition: \(actualPosition), start: \(start)")
+    guard actualPosition >= 0  else { return 0 }
+    guard actualPosition < text.count else { return text.count }
     let characters = Array(text)
-    var newPosition = basePosition
+    var newPosition = actualPosition
     var currentChar: Character
     
     if start {

--- a/eWriter2Tests/eWriter2Tests.swift
+++ b/eWriter2Tests/eWriter2Tests.swift
@@ -18,19 +18,18 @@ final class eWriter2Tests: XCTestCase {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
     }
 
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-        // Any test you write for XCTest can be annotated as throws and async.
-        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
-        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+    func testRecalculateCursorPositionAcrossNewlines() throws {
+        let text = "line1\nline2\nline3"
+        XCTAssertEqual(recalculateCursorPosition(text: text, position: 5), 6)
+        XCTAssertEqual(recalculateCursorPosition(text: text, position: 10), 12)
     }
 
-    func testPerformanceExample() throws {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
-        }
+    func testGetCursorParagraphInfoAtDocumentStart() throws {
+        let text = "line1\nline2"
+        let info = getCursorParagraphInfo(text: text, cursorPosition: 0, selectionStart: nil, selectionEnd: nil)
+        XCTAssertNotNil(info)
+        XCTAssertEqual(info?.paragraphIndex, 0)
+        XCTAssertEqual(info?.positionInParagraph, 0)
     }
 
 }


### PR DESCRIPTION
## Summary
- Correct cursor index mapping by iterating visible characters and ignoring newlines
- Remove fallback-to-end when cursor at document start and add tests
- Add unit tests for cursor mapping across newlines and paragraph calculations

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -scheme eWriter2Tests -project iBirde.xcodeproj test` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_68b9691f70048332ab6856faf320120f